### PR TITLE
Error handling 예시 추가

### DIFF
--- a/src/app/error-handling/error.tsx
+++ b/src/app/error-handling/error.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+  return (
+    <div>
+      Something Went Wrong!{' '}
+      <button type="button" onClick={() => reset()} className="bg-amber-600 px-2">
+        Try agin
+      </button>
+    </div>
+  )
+}

--- a/src/app/error-handling/error.tsx
+++ b/src/app/error-handling/error.tsx
@@ -42,7 +42,7 @@ export default function Error({
   }, [error])
   return (
     <div>
-      Something Went Wrong!{' '}
+      Something Went Wrong!
       <button type="button" onClick={() => reset()} className="bg-amber-600 px-2">
         Try agin
       </button>

--- a/src/app/error-handling/error.tsx
+++ b/src/app/error-handling/error.tsx
@@ -2,6 +2,34 @@
 
 import { useEffect } from 'react'
 
+/**
+ *
+ * Routing => [Error Handling]
+ *
+ * 1. error 스페셜 파일은 런타임 오류를 처리하며, 때문에 클라이언트 사이드에서 작동한다.
+ *
+ * 2. error 스페셜 파일은 그 자체로 컴포넌트 하이어라키에서 사용되지 않고 ErrorBoundary 리액트 컴포넌트를 생성한다.
+ *    error 스페셜 파일에서 내보낸 컴포넌트는 Error Boundary 컴포넌트의 fallback 컴포넌트로 사용된다.
+ *    error 스페셜 파일은 실제로 아래와 같은 리액트 컴포넌트 계층을 갖는다.
+ *
+ *    <layout>
+ *      <Error fallback={<Error />}>
+ *        <Page />
+ *      </Error>
+ *    </layout>
+ *
+ * 3. 위에서 알 수 있듯이, Error컴포넌트는 직접적으로 컴포넌트 계층에 포함되지 않기 때문에 자신이 클라이언트 컴포넌트여도
+ *    하위 파일들이 서버, 클라이언트 컴포넌트가 되는지에 대해 영향을 주지 않는다.
+ *
+ * 4. error 프로퍼티는 에러에 대한 내용을 가지고있다.
+ *    아래의 코드에서는, page파일에서 'Some critical errors have occurred!'에러를 발생시키고 있기 때문에, 해당에러가 출력된다.
+ *
+ * 5. reset 프로퍼티는 리렌더링시킬 수 있는 함수인데, 리렌더링의 범위는 ErrorBoundary 컴포넌트의 자손 컴포넌트들로 제한된다.
+ *
+ *
+ * ref : https://nextjs.org/docs/app/building-your-application/routing/error-handling
+ *
+ * */
 export default function Error({
   error,
   reset,

--- a/src/app/error-handling/error.tsx
+++ b/src/app/error-handling/error.tsx
@@ -6,9 +6,12 @@ import { useEffect } from 'react'
  *
  * Routing => [Error Handling]
  *
- * 1. error 스페셜 파일은 런타임 오류를 처리하며, 때문에 클라이언트 사이드에서 작동한다.
  *
- * 2. error 스페셜 파일은 그 자체로 컴포넌트 하이어라키에서 사용되지 않고 ErrorBoundary 리액트 컴포넌트를 생성한다.
+ * 1. error 스페셜 파일은 런타임 에러를 처리하며, 때문에 클라이언트 사이드에서 작동한다.
+ *
+ * 2. 각 컴포넌트에서 에러가 발생하면 해당 에러는 가장 가까운 상위 error파일에 프로퍼티 전달된다.
+ *
+ * 3. error 스페셜 파일은 그 자체로 컴포넌트 하이어라키에서 사용되지 않고 ErrorBoundary 리액트 컴포넌트를 생성한다.
  *    error 스페셜 파일에서 내보낸 컴포넌트는 Error Boundary 컴포넌트의 fallback 컴포넌트로 사용된다.
  *    error 스페셜 파일은 실제로 아래와 같은 리액트 컴포넌트 계층을 갖는다.
  *
@@ -18,13 +21,16 @@ import { useEffect } from 'react'
  *      </Error>
  *    </layout>
  *
- * 3. 위에서 알 수 있듯이, Error컴포넌트는 직접적으로 컴포넌트 계층에 포함되지 않기 때문에 자신이 클라이언트 컴포넌트여도
+ * 4. 위에서 알 수 있듯이, Error컴포넌트는 직접적으로 컴포넌트 계층에 포함되지 않기 때문에 자신이 클라이언트 컴포넌트여도
  *    하위 파일들이 서버, 클라이언트 컴포넌트가 되는지에 대해 영향을 주지 않는다.
  *
- * 4. error 프로퍼티는 에러에 대한 내용을 가지고있다.
+ * 5. error 프로퍼티는 에러에 대한 내용을 가지고있다.
  *    아래의 코드에서는, page파일에서 'Some critical errors have occurred!'에러를 발생시키고 있기 때문에, 해당에러가 출력된다.
  *
- * 5. reset 프로퍼티는 리렌더링시킬 수 있는 함수인데, 리렌더링의 범위는 ErrorBoundary 컴포넌트의 자손 컴포넌트들로 제한된다.
+ * 6. reset 프로퍼티는 리렌더링 시킬 수 있는 함수인데, 리렌더링의 범위는 ErrorBoundary 컴포넌트의 자손 컴포넌트들로 제한된다.
+ *
+ * 7. 서버 컴포넌트 내에서 오류가 발생하면 민감한 정보를 제거한 후 message와 digest 속성만 포함된 에러 객체가 전달된다.
+ *    message 속성에는 오류에 대한 일반 메세지가 포함되며, digest 속성에는 서버 측 로그와의 일치를 확인할 수 있는 에러 해시가 포함된다.
  *
  *
  * ref : https://nextjs.org/docs/app/building-your-application/routing/error-handling

--- a/src/app/error-handling/layout.tsx
+++ b/src/app/error-handling/layout.tsx
@@ -1,5 +1,20 @@
 import { ReactNode } from 'react'
 
+/**
+ *
+ * Routing => [Error Handling]
+ *
+ *
+ * 1. layout은 동일한 세그먼트에 있는 error가 생성하는 ErrorBoundary 컴포넌트 외부에 있기 때문에 에러가 발생해도 정상적으로 렌더링된다.
+ *    template역시 error의 외부 계층에 존재하기 때문에 마찬가지이다.
+ *
+ * 2. layout의 에러를 감지하려면 상위 세그먼트의 error를 이용해야한다. 그러나 이렇게 하면 상위 세그먼트의 page가 ErrorBoundary 컴포넌트에 같이 포함된다.
+ *    그렇기 때문에 layout이나 template의 경우 내부적으로 에러를 핸들링하는 방향을 고민해봐야한다.
+ *
+ *
+ * ref : https://nextjs.org/docs/app/building-your-application/routing/error-handling
+ *
+ * */
 export default function ErrorHandlingLayout({ children }: { children: ReactNode }) {
   return (
     <section>

--- a/src/app/error-handling/layout.tsx
+++ b/src/app/error-handling/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function ErrorHandlingLayout({ children }: { children: ReactNode }) {
+  return (
+    <section>
+      Hello ErrorHandlingLayout!<div>{children}</div>
+    </section>
+  )
+}

--- a/src/app/error-handling/page.tsx
+++ b/src/app/error-handling/page.tsx
@@ -1,0 +1,3 @@
+export default function ErrorHandlingPage() {
+  throw new Error('Some critical errors have occurred!')
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ *
+ * Routing => [Error Handling]#Handling Errors in Root Layouts
+ *
+ *
+ * 1. 어떤 error파일도 루트 레이아웃을 포함할 수 없기 때문에, 루트 레이아웃의 에러는 일반적인 error파일로 잡아낼 수 없다.
+ *
+ * 2. 1번과 같은 이유 때문에 nextjs에서는 루트 레이웃의 에러를 핸들링할 수 있는 global-error 스페셜 파일을 제공한다.
+ *
+ * 3. global-error의 컴포넌트는 <html>, <body>태그를 포함하고 있는 루트 레이아웃을 대체해야하기 때문에 자체적으로 <html>, <body> 태그를 정의해야한다.
+ *
+ * 4. global-error 파일은 프로덕션 환경에서만 활성화되고, 개발 환경에서는 오류 오버레이를 대신 보여준다.
+ *
+ *
+ * ref : https://nextjs.org/docs/app/building-your-application/routing/error-handling#handling-errors-in-root-layouts
+ *
+ * */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+  return (
+    <html>
+      <body>
+        Something Went Wrong in Global!
+        <button type="button" onClick={() => reset()} className="bg-amber-600 px-2">
+          Try agin
+        </button>
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
# Description

1. error-handling 세그먼트 추가 : error 스페셜 파일에 대한 예시와 설명, 다른 스페셜 파일과의 상호작용에 대한 예시와 설명 추가
2. global-error.tsx 추가 : error.tsx로 처리할 수 없는 루트 레이아웃이나 루트 템플릿에 관한 에러를 처리하는 global-error 스페셜 파일에 대한 예시와 설명 추가

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Other Information

ref : https://nextjs.org/docs/app/building-your-application/routing/error-handling